### PR TITLE
Update the repository address and the version

### DIFF
--- a/Formula/git-latexdiff.rb
+++ b/Formula/git-latexdiff.rb
@@ -1,11 +1,11 @@
 class GitLatexdiff < Formula
   homepage "https://gitorious.org/git-latexdiff"
-  url "https://gitorious.org/git-latexdiff/git-latexdiff.git",
-    :tag => "v1.0.0",
-    :revision => "c3f74f5559867111f118600e6d2bf778a3f13754"
+  url "https://gitlab.com/git-latexdiff/git-latexdiff.git",
+    :tag => "v1.1.2",
+    :revision => "292602b2375360905a98d1deec5411110688b860"
 
   depends_on :tex
-  depends_on "latexdiff" => :recommended
+  depends_on "latexdiff"
 
   def install
     bin.install "git-latexdiff"
@@ -14,7 +14,7 @@ class GitLatexdiff < Formula
   test do
     test_git_dir = testpath/"gldtest"
     test_pdf = testpath/"test.pdf"
-    system "git", "clone", "https://gitorious.org/git-latexdiff/git-latexdiff.git", test_git_dir
+    system "git", "clone", "https://gitlab.com/git-latexdiff/git-latexdiff.git", test_git_dir
     (test_git_dir/"tests/bib").cd do
       system "git", "latexdiff", "@~5", "--no-view", "-o", test_pdf
     end

--- a/Formula/git-latexdiff.rb
+++ b/Formula/git-latexdiff.rb
@@ -1,5 +1,5 @@
 class GitLatexdiff < Formula
-  homepage "https://gitorious.org/git-latexdiff"
+  homepage "https://gitlab.com/git-latexdiff/git-latexdiff"
   url "https://gitlab.com/git-latexdiff/git-latexdiff.git",
     :tag => "v1.1.2",
     :revision => "292602b2375360905a98d1deec5411110688b860"


### PR DESCRIPTION
The repository of git-latexdiff has moved so I updated the link. I also upgraded the version from version 1.0.0 to 1.1.2.