### PR TITLE
Update URL and revision of git-latexdiff

### DIFF
--- a/Formula/git-latexdiff.rb
+++ b/Formula/git-latexdiff.rb
@@ -1,8 +1,8 @@
 class GitLatexdiff < Formula
-  homepage "https://gitorious.org/git-latexdiff"
-  url "https://gitorious.org/git-latexdiff/git-latexdiff.git",
-    :tag => "v1.0.0",
-    :revision => "c3f74f5559867111f118600e6d2bf778a3f13754"
+  homepage "https://gitlab.com/git-latexdiff/git-latexdiff"
+  url "https://gitlab.com/git-latexdiff/git-latexdiff.git",
+    :tag => "v1.1.2",
+    :revision => "292602b2375360905a98d1deec5411110688b860"
 
   depends_on :tex
   depends_on "latexdiff" => :recommended
@@ -14,7 +14,7 @@ class GitLatexdiff < Formula
   test do
     test_git_dir = testpath/"gldtest"
     test_pdf = testpath/"test.pdf"
-    system "git", "clone", "https://gitorious.org/git-latexdiff/git-latexdiff.git", test_git_dir
+    system "git", "clone", "https://gitlab.com/git-latexdiff/git-latexdiff.git", test_git_dir
     (test_git_dir/"tests/bib").cd do
       system "git", "latexdiff", "@~5", "--no-view", "-o", test_pdf
     end


### PR DESCRIPTION
gitorious merged with gitlab, so change the repository URL from
gitorious to gitlab. Also bump the revision tag from 1.0.0 (1yr old) to
1.1.2